### PR TITLE
com.webos.sam.role.json.in: Add additional permissions

### DIFF
--- a/files/sysbus/com.webos.sam.role.json.in
+++ b/files/sysbus/com.webos.sam.role.json.in
@@ -28,7 +28,8 @@
                 "com.webos.service.tvpower",
                 "com.palm.webappmanager",
                 "com.webos.settingsservice",
-                "com.webos.surfacemanager"
+                "com.webos.surfacemanager",
+                "com.webos.lunasend-*"
             ]
         }
     ]


### PR DESCRIPTION
Fixes:

Mar 17 06:07:17 qemux86-64 ls-hubd[243]: [] [pmlog] ls-hubd LSHUB_NO_OUT_PERMS {"DEST_APP_ID":"com.webos.lunasend-1432","SRC_APP_ID":"com.webos.service.applicationManager","EXE":"/usr/sbin/sam","PID":604} "com.webos.service.applicationManager" does not have sufficient outbound permissions to communicate with "com.webos.lunasend-1432" (cmdline: /usr/sbin/sam)

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>