### PR TITLE
com.webos.sam.role.json.in: Fix various outbound permission issues

### DIFF
--- a/files/sysbus/com.webos.sam.role.json.in
+++ b/files/sysbus/com.webos.sam.role.json.in
@@ -28,7 +28,40 @@
                 "com.webos.service.tvpower",
                 "com.palm.webappmanager",
                 "com.webos.settingsservice",
-                "com.webos.surfacemanager"
+                "com.webos.surfacemanager",
+                "com.webos.surfacemanager-cardshell",
+                "com.webos.lunasend-*",
+                "com.palm.applicationManager",
+                "com.palm.universalsearch",
+                "com.palm.systemui-*"
+            ]
+        },
+        {
+            "service":"com.webos.service.applicationManager",
+            "outbound":[
+                "*",
+                "com.webos.appInstallService",
+                "com.webos.booster",
+                "com.webos.bootManager",
+                "com.webos.memorymanager",
+                "com.webos.notification",
+                "com.webos.service.attachedstoragemanager",
+                "com.webos.service.bus",
+                "com.webos.service.config",
+                "com.webos.service.db",
+                "com.webos.service.downloadmanager",
+                "com.webos.service.power2",
+                "com.webos.service.sdx",
+                "com.webos.service.sm",
+                "com.webos.service.tvpower",
+                "com.palm.webappmanager",
+                "com.webos.settingsservice",
+                "com.webos.surfacemanager",
+                "com.webos.surfacemanager-cardshell",
+                "com.webos.lunasend-*",
+                "com.palm.applicationManager",
+                "com.palm.universalsearch",
+                "com.palm.systemui-*"
             ]
         }
     ]


### PR DESCRIPTION
Fixes:

2022-04-29T20:33:41.693472Z [5.988982127] kern.err ls-hubd [] ls-hubd LSHUB_NO_OUT_PERMS {"DEST_APP_ID":"com.palm.universalsearch","SRC_APP_ID":"com.webos.service.applicationManager","EXE":"/usr/sbin/sam","PID":601} "com.webos.service.applicationManager" does not have sufficient outbound permissions to communicate with "com.palm.universalsearch" (cmdline: /usr/sbin/sam)

Apr 29 20:38:53 qemux86-64 ls-hubd[241]: [] [pmlog] ls-hubd LSHUB_NO_OUT_PERMS {"DEST_APP_ID":"com.webos.bootManager","SRC_APP_ID":"com.webos.service.applicationManager","EXE":"/usr/sbin/sam","PID":639} "com.webos.service.applicationManager" does not have sufficient outbound permissions to communicate with "com.webos.bootManager" (cmdline: /usr/sbin/sam)

Apr 29 20:38:56 qemux86-64 ls-hubd[241]: [] [pmlog] ls-hubd LSHUB_NO_OUT_PERMS {"DEST_APP_ID":"com.webos.surfacemanager-cardshell","SRC_APP_ID":"com.webos.service.applicationManager","EXE":"/usr/sbin/sam","PID":639} "com.webos.service.applicationManager" does not have sufficient outbound permissions to communicate with "com.webos.surfacemanager-cardshell" (cmdline: /usr/sbin/sam)

Apr 29 20:38:55 qemux86-64 ls-hubd[241]: [] [pmlog] ls-hubd LSHUB_NO_OUT_PERMS {"DEST_APP_ID":"com.palm.applicationManager","SRC_APP_ID":"com.webos.service.applicationManager","EXE":"/usr/sbin/sam","PID":639} "com.webos.service.applicationManager" does not have sufficient outbound permissions to communicate with "com.palm.applicationManager" (cmdline: /usr/sbin/sam)

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>